### PR TITLE
fixed version flag output text

### DIFF
--- a/deb/usr/local/bin/lkdt
+++ b/deb/usr/local/bin/lkdt
@@ -59,7 +59,7 @@ while [[ $# -gt 0 ]]; do
             shift 2 ;;
         -q|--quiet) SHOW_PROGRESS=false; shift ;;
         -v|--verbose) VERBOSE=true; shift ;;
-        --version) echo "ltd version $VERSION"; exit 0 ;;
+        --version) echo "lkdt version $VERSION"; exit 0 ;;
         -h|--help) usage ;;
         *) echo -e "${RED}Unknown option:${NC} $1"; usage ;;
     esac


### PR DESCRIPTION
The version output text had the old "ltd" name of the command. Replaced with new "lkdt" name.